### PR TITLE
Improved sorting, list/group views, remember settings and some UI fixes 

### DIFF
--- a/server/hashtag.go
+++ b/server/hashtag.go
@@ -164,26 +164,22 @@ func groupHashtagsByPrefix(tags []HashtagCount) []HashtagGroup {
 	
 	for _, tag := range tags {
 		parts := strings.Split(tag.Tag, "-")
-		if len(parts) > 1 {
+		// Only group hashtags that contain hyphens (multi-word)
+		if len(parts) > 1 && strings.Contains(tag.Tag, "-") {
 			prefix := parts[0]
 			if _, ok := groups[prefix]; !ok {
 				groups[prefix] = []HashtagCount{}
 			}
 			groups[prefix] = append(groups[prefix], tag)
-		} else {
-			// Handle tags without hyphens by using themselves as the prefix
-			if _, ok := groups[tag.Tag]; !ok {
-				groups[tag.Tag] = []HashtagCount{}
-			}
-			groups[tag.Tag] = append(groups[tag.Tag], tag)
 		}
+		// Skip single-word hashtags - they won't be grouped
 	}
 
 	// Convert map to sorted slice
 	result := make([]HashtagGroup, 0, len(groups))
 	for prefix, tags := range groups {
 		// Only create a group if there are multiple tags with the same prefix
-		if len(tags) > 1 || !strings.Contains(prefix, "-") {
+		if len(tags) > 1 {
 			result = append(result, HashtagGroup{
 				Prefix: prefix,
 				Tags:   tags,

--- a/webapp/src/Components/RHS/HashtagList.tsx
+++ b/webapp/src/Components/RHS/HashtagList.tsx
@@ -2,12 +2,28 @@ import React, {useEffect, useState} from 'react';
 import {useSelector} from 'react-redux';
 import {fetchHashtags, fetchTeamHashtags} from '../../client';
 
+// Add CSS styles for hover effects
+const style = document.createElement('style');
+style.textContent = `
+  .hashtag-button:hover {
+    background-color: rgba(var(--center-channel-color-rgb), 0.04) !important;
+    border-color: rgba(var(--center-channel-color-rgb), 0.04) !important;
+    transform: translateY(-1px) !important;
+  }
+  .accordion-button:hover {
+    background-color: rgba(var(--center-channel-color-rgb), 0.04) !important;
+    border-color: rgba(var(--center-channel-color-rgb), 0.04) !important;
+    transform: translateY(-1px) !important;
+  }
+`;
+document.head.appendChild(style);
+
 type Tab = 'channel' | 'team';
 
 interface HashtagData {
     tag: string;
     count: number;
-    last_used?: number;
+    lastUsed?: number;
 }
 
 interface HashtagGroup {
@@ -78,10 +94,7 @@ const styles = {
         borderRadius: '4px',
         color: 'var(--link-color)',
         cursor: 'pointer',
-        transition: 'all 0.2s ease',
-        '&:hover': {
-            backgroundColor: 'rgba(var(--center-channel-color-rgb), 0.04)'
-        }
+        transition: 'all 0.2s ease'
     },
     tag: {
         fontWeight: 600 as const
@@ -139,10 +152,7 @@ const styles = {
         borderRadius: '4px',
         color: 'var(--center-channel-color)',
         cursor: 'pointer',
-        transition: 'all 0.2s ease',
-        '&:hover': {
-            backgroundColor: 'rgba(var(--center-channel-color-rgb), 0.04)'
-        }
+        transition: 'all 0.2s ease'
     },
     accordionPanel: {
         padding: '8px 16px'
@@ -164,11 +174,46 @@ export default function HashtagList({channelId, onSelect}: {channelId: string; o
     const [error, setError] = useState<string | null>(null);
     const [loading, setLoading] = useState(true);
     const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
+    const [showGrouped, setShowGrouped] = useState(false);
+    const [hasUserPreferences, setHasUserPreferences] = useState(false);
+    const [rememberSettings, setRememberSettings] = useState(false);
     const [sortConfig, setSortConfig] = useState<{sortBy: 'time' | 'count' | 'name'; sortOrder: 'asc' | 'desc'}>({
         sortBy: 'time',
         sortOrder: 'desc'
     });
     const teamId = useSelector((state: any) => state.entities.teams.currentTeamId);
+
+    // Default settings
+    const DEFAULT_SETTINGS = {
+        showGrouped: false,
+        sortBy: 'time' as const,
+        sortOrder: 'desc' as const
+    };
+
+    // Helper functions for localStorage
+    const getStoredPreferences = () => {
+        try {
+            const stored = localStorage.getItem('hashtag-list-preferences');
+            return stored ? JSON.parse(stored) : null;
+        } catch {
+            return null;
+        }
+    };
+
+    const savePreferences = (preferences: any) => {
+        try {
+            localStorage.setItem('hashtag-list-preferences', JSON.stringify(preferences));
+        } catch {
+            // Handle storage errors silently
+        }
+    };
+
+    const checkForUserPreferences = () => {
+        const isDifferent = showGrouped !== DEFAULT_SETTINGS.showGrouped ||
+                           sortConfig.sortBy !== DEFAULT_SETTINGS.sortBy ||
+                           sortConfig.sortOrder !== DEFAULT_SETTINGS.sortOrder;
+        setHasUserPreferences(isDifferent);
+    };
 
     const toggleGroup = (prefix: string) => {
         setExpandedGroups(prev => {
@@ -189,16 +234,21 @@ export default function HashtagList({channelId, onSelect}: {channelId: string; o
                 ? (prevConfig.sortOrder === 'desc' ? 'asc' : 'desc')
                 : 'desc'
         }));
+        
+        // Auto-expand all groups when sorting in grouped mode (Approach 4)
+        if (showGrouped && data) {
+            setExpandedGroups(new Set(data.groups.map(g => g.prefix)));
+        }
     };
 
-    const sortHashtags = (tags: {tag: string; count: number; last_used?: number}[]) => {
+    const sortHashtags = (tags: {tag: string; count: number; lastUsed?: number}[]) => {
         if (!tags || tags.length === 0) return [];
         
         return [...tags].sort((a, b) => {
             switch (sortConfig.sortBy) {
                 case 'time':
-                    const aTime = a.last_used || 0;
-                    const bTime = b.last_used || 0;
+                    const aTime = a.lastUsed || 0;
+                    const bTime = b.lastUsed || 0;
                     return sortConfig.sortOrder === 'desc' ? bTime - aTime : aTime - bTime;
                 case 'count':
                     return sortConfig.sortOrder === 'desc' ? b.count - a.count : a.count - b.count;
@@ -208,6 +258,40 @@ export default function HashtagList({channelId, onSelect}: {channelId: string; o
                         ? b.tag.localeCompare(a.tag)
                         : a.tag.localeCompare(b.tag);
             }
+        });
+    };
+
+    // Sort groups by the same criteria as hashtags (Approach 1)
+    const sortGroups = (groups: HashtagGroup[]) => {
+        return [...groups].sort((a, b) => {
+            const getGroupMetric = (group: HashtagGroup) => {
+                switch (sortConfig.sortBy) {
+                    case 'time':
+                        // Most recent hashtag in the group
+                        return Math.max(...group.tags.map(tag => tag.lastUsed || 0));
+                    case 'count':
+                        // Total count of all hashtags in group
+                        return group.tags.reduce((sum, tag) => sum + tag.count, 0);
+                    case 'name':
+                        // Sort by group prefix
+                        return group.prefix;
+                    default:
+                        return group.prefix;
+                }
+            };
+
+            const aMetric = getGroupMetric(a);
+            const bMetric = getGroupMetric(b);
+            
+            if (sortConfig.sortBy === 'name') {
+                return sortConfig.sortOrder === 'desc'
+                    ? (bMetric as string).localeCompare(aMetric as string)
+                    : (aMetric as string).localeCompare(bMetric as string);
+            }
+            
+            return sortConfig.sortOrder === 'desc' 
+                ? (bMetric as number) - (aMetric as number)
+                : (aMetric as number) - (bMetric as number);
         });
     };
 
@@ -230,10 +314,43 @@ export default function HashtagList({channelId, onSelect}: {channelId: string; o
             });
     }, [channelId, teamId, activeTab]);
 
+    // Load preferences on component mount
+    useEffect(() => {
+        const stored = getStoredPreferences();
+        if (stored && stored.remember) {
+            setShowGrouped(stored.showGrouped ?? DEFAULT_SETTINGS.showGrouped);
+            setSortConfig({
+                sortBy: stored.sortBy ?? DEFAULT_SETTINGS.sortBy,
+                sortOrder: stored.sortOrder ?? DEFAULT_SETTINGS.sortOrder
+            });
+            setRememberSettings(true);
+            setHasUserPreferences(true);
+        }
+    }, []);
+
+    // Check for changes when settings change
+    useEffect(() => {
+        checkForUserPreferences();
+    }, [showGrouped, sortConfig]);
+
+    // Save preferences when checkbox is checked
+    useEffect(() => {
+        if (rememberSettings) {
+            savePreferences({
+                showGrouped,
+                sortBy: sortConfig.sortBy,
+                sortOrder: sortConfig.sortOrder,
+                remember: true
+            });
+        } else {
+            localStorage.removeItem('hashtag-list-preferences');
+        }
+    }, [rememberSettings, showGrouped, sortConfig]);
+
     if (error) {
         return (
             <div className="sidebar--right__content" style={styles.container}>
-                <div style={{padding: '16px'}}>Error: {error}</div>
+                <div style={{padding: '24px'}}>Error: {error}</div>
             </div>
         );
     }
@@ -241,7 +358,7 @@ export default function HashtagList({channelId, onSelect}: {channelId: string; o
     if (!data || loading) {
         return (
             <div className="sidebar--right__content" style={styles.container}>
-                <div style={{padding: '16px'}}>Loading...</div>
+                <div style={{padding: '24px'}}>Loading...</div>
             </div>
         );
     }
@@ -269,6 +386,18 @@ export default function HashtagList({channelId, onSelect}: {channelId: string; o
                 </button>
             </div>
             <div style={styles.sortHeader}>
+                <button
+                    onClick={() => setShowGrouped(!showGrouped)}
+                    style={{
+                        ...styles.sortButton,
+                        ...(showGrouped ? styles.sortButtonActive : {}),
+                        marginRight: '12px',
+                        borderRight: '1px solid rgba(var(--center-channel-color-rgb), 0.16)',
+                        paddingRight: '12px'
+                    }}
+                >
+                    {showGrouped ? 'Grouped' : 'List View'}
+                </button>
                 <button
                     onClick={() => handleSort('time')}
                     style={{
@@ -312,59 +441,115 @@ export default function HashtagList({channelId, onSelect}: {channelId: string; o
                     )}
                 </button>
             </div>
+            {hasUserPreferences && (
+                <div style={{
+                    padding: '8px 16px',
+                    borderBottom: '1px solid rgba(var(--center-channel-color-rgb), 0.08)',
+                    marginBottom: '8px',
+                    backgroundColor: 'rgba(var(--center-channel-color-rgb), 0.02)'
+                }}>
+                    <label style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        fontSize: '12px',
+                        color: 'rgba(var(--center-channel-color-rgb), 0.72)',
+                        cursor: 'pointer'
+                    }}>
+                        <input
+                            type="checkbox"
+                            checked={rememberSettings}
+                            onChange={(e) => setRememberSettings(e.target.checked)}
+                            style={{
+                                marginRight: '6px',
+                                accentColor: 'var(--button-bg)'
+                            }}
+                        />
+                        Remember these settings
+                    </label>
+                </div>
+            )}
             <div style={styles.list}>
-                {data.groups.map((group) => {
-                    const sortedGroupTags = sortHashtags(group.tags);
-                    return (
-                        <div key={group.prefix} style={styles.accordionItem}>
-                        <button
-                            onClick={() => toggleGroup(group.prefix)}
-                            style={styles.accordionButton}
-                        >
-                            <span style={styles.groupPrefix}>{group.prefix}</span>
-                            <span style={styles.groupTagCount}>
-                                {group.tags.length} {group.tags.length === 1 ? 'tag' : 'tags'}
-                            </span>
-                        </button>
-                        {expandedGroups.has(group.prefix) && (
-                            <div style={styles.accordionPanel}>
-                                {sortedGroupTags.map(({tag, count}) => (
-                                    <div key={tag} style={styles.listItem}>
-                                        <button
-                                            onClick={() => {
-                                                console.log('HashtagList: Selecting tag', tag, 'activeTab:', activeTab, 'channelId:', channelId);
-                                                onSelect(tag, activeTab === 'channel' ? channelId : undefined);
-                                            }}
-                                            style={styles.hashtagButton}
-                                        >
-                                            <span style={styles.tag}>#{tag}</span>
-                                            <span style={styles.count}>
-                                                {count} {count === 1 ? 'post' : 'posts'}
-                                            </span>
-                                        </button>
+                {showGrouped ? (
+                    <>
+                        {/* Grouped view */}
+                        {sortGroups(data.groups).map((group) => {
+                            const sortedGroupTags = sortHashtags(group.tags);
+                            return (
+                                <div key={group.prefix} style={styles.accordionItem}>
+                                <button
+                                    onClick={() => toggleGroup(group.prefix)}
+                                    style={styles.accordionButton}
+                                    className="accordion-button"
+                                >
+                                    <span style={styles.groupPrefix}>{group.prefix}</span>
+                                    <span style={styles.groupTagCount}>
+                                        {group.tags.length} {group.tags.length === 1 ? 'tag' : 'tags'}
+                                    </span>
+                                </button>
+                                {expandedGroups.has(group.prefix) && (
+                                    <div style={styles.accordionPanel}>
+                                        {sortedGroupTags.map(({tag, count}) => (
+                                            <div key={tag} style={styles.listItem}>
+                                                <button
+                                                    onClick={() => {
+                                                        console.log('HashtagList: Selecting tag', tag, 'activeTab:', activeTab, 'channelId:', channelId);
+                                                        onSelect(tag, activeTab === 'channel' ? channelId : undefined);
+                                                    }}
+                                                    style={styles.hashtagButton}
+                                                    className="hashtag-button"
+                                                >
+                                                    <span style={styles.tag}>#{tag}</span>
+                                                    <span style={styles.count}>
+                                                        {count} {count === 1 ? 'post' : 'posts'}
+                                                    </span>
+                                                </button>
+                                            </div>
+                                        ))}
                                     </div>
-                                ))}
+                                )}
                             </div>
-                        )}
-                    </div>
-                    );
-                })}
-                {/* Show ungrouped tags (those without prefixes) */}
-                {sortHashtags(
-                    data.hashtags.filter(tag => !data.groups.some(g => g.tags.some(t => t.tag === tag.tag)))
-                ).map(({tag, count}) => (
-                        <div key={tag} style={styles.listItem}>
-                            <button
-                                onClick={() => onSelect(tag, activeTab === 'channel' ? channelId : undefined)}
-                                style={styles.hashtagButton}
-                            >
-                                <span style={styles.tag}>#{tag}</span>
-                                <span style={styles.count}>
-                                    {count} {count === 1 ? 'post' : 'posts'}
-                                </span>
-                            </button>
-                        </div>
-                    ))}
+                            );
+                        })}
+                        {/* Show ungrouped tags (those without prefixes) */}
+                        {sortHashtags(
+                            data.hashtags.filter(tag => !data.groups.some(g => g.tags.some(t => t.tag === tag.tag)))
+                        ).map(({tag, count}) => (
+                                <div key={tag} style={styles.listItem}>
+                                    <button
+                                        onClick={() => onSelect(tag, activeTab === 'channel' ? channelId : undefined)}
+                                        style={styles.hashtagButton}
+                                        className="hashtag-button"
+                                    >
+                                        <span style={styles.tag}>#{tag}</span>
+                                        <span style={styles.count}>
+                                            {count} {count === 1 ? 'post' : 'posts'}
+                                        </span>
+                                    </button>
+                                </div>
+                            ))}
+                    </>
+                ) : (
+                    <>
+                        {/* Flat list view */}
+                        {sortHashtags([
+                            ...data.groups.flatMap(group => group.tags),
+                            ...data.hashtags.filter(tag => !data.groups.some(g => g.tags.some(t => t.tag === tag.tag)))
+                        ]).map(({tag, count}) => (
+                            <div key={tag} style={styles.listItem}>
+                                <button
+                                    onClick={() => onSelect(tag, activeTab === 'channel' ? channelId : undefined)}
+                                    style={styles.hashtagButton}
+                                    className="hashtag-button"
+                                >
+                                    <span style={styles.tag}>#{tag}</span>
+                                    <span style={styles.count}>
+                                        {count} {count === 1 ? 'post' : 'posts'}
+                                    </span>
+                                </button>
+                            </div>
+                        ))}
+                    </>
+                )}
             </div>
         </div>
     );

--- a/webapp/src/Components/RHS/TagResults.tsx
+++ b/webapp/src/Components/RHS/TagResults.tsx
@@ -37,26 +37,6 @@ const getSearchResult = () => {
     return null;
 };
 
-// Import SearchResult component from Mattermost webapp
-const getSearchResult = () => {
-    // First try to get it from modern webapp structure
-    if ((window as any).Components?.SearchResults?.default?.SearchResult) {
-        return (window as any).Components.SearchResults.default.SearchResult;
-    }
-    
-    // Try legacy structure
-    if ((window as any).Components?.SearchResults?.SearchResult) {
-        return (window as any).Components.SearchResults.SearchResult;
-    }
-    
-    // Try global scope
-    if ((window as any).SearchResult) {
-        return (window as any).SearchResult;
-    }
-    
-    return null;
-};
-
 // Add TypeScript JSX definitions
 declare global {
     namespace JSX {
@@ -81,7 +61,7 @@ const styles = {
     content: {
         flex: '1 1 auto',
         overflow: 'auto',
-        padding: '0 24px 24px', // Match hashtag list padding
+        padding: '0 24px 40px', // Added more bottom padding
     },
     header: {
         display: 'flex',
@@ -193,12 +173,41 @@ export default function TagResults({teamId, tag, onBack, channelId}: {teamId: st
           <h3 style={styles.title}>#{tag}</h3>
         </div>
 
-        {error && <div style={{color: 'var(--error-text)'}}>Error: {error}</div>}
+        {error && (
+          <div style={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            padding: '40px 20px',
+            color: 'var(--error-text)',
+            fontSize: '14px'
+          }}>
+            Error: {error}
+          </div>
+        )}
         
         {loading ? (
-          <div>Loading posts...</div>
+          <div style={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            padding: '40px 20px',
+            color: 'rgba(var(--center-channel-color-rgb), 0.72)',
+            fontSize: '14px'
+          }}>
+            Loading posts...
+          </div>
         ) : posts.length === 0 ? (
-          <div>No messages found with #{tag}</div>
+          <div style={{
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            padding: '40px 20px',
+            color: 'rgba(var(--center-channel-color-rgb), 0.72)',
+            fontSize: '14px'
+          }}>
+            No messages found with #{tag}
+          </div>
         ) : (
           <div className="search-items-container" style={styles.postList}>
             {posts.map((post: HashtagPost) => {


### PR DESCRIPTION
- Implement new sorting: sort both groups and hashtags with auto-expand
- Exclude single-word hashtags from server-side grouping for cleaner organization
- Add remember settings functionality with localStorage persistence
- Set default view to ungrouped (list view) for better first-time user experience